### PR TITLE
Update dimens.xml

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/dimens.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="rounded_corner_content_padding">12dp</dimen>
+
+    <!-- Burn-in protection -->
+    <dimen name="horizontal_max_swift">3.0dp</dimen>
+    <dimen name="vertical_max_swift">1.0dp</dimen>
 </resources>


### PR DESCRIPTION
This update determines the movement that Burnin protection should do during the use of the screen, causing it to not stand and causing damage to the device screen