### PR TITLE
dipper: audio: Enabled IIR0/Anc Filters

### DIFF
--- a/audio/mixer_paths_overlay_static.xml
+++ b/audio/mixer_paths_overlay_static.xml
@@ -22,6 +22,13 @@
     <ctl name="QUAT_MI2S_TX Format" value="S24_LE" />
     <ctl name="QUAT_MI2S_TX SampleRate" value="KHZ_48" />
     <ctl name="External AMIC2 Mux" value="Dual_ADC" />
+    
+    <!-- IIR0 Voice/ANC -->
+    <ctl name="IIR0 Enable Band1" value="1" />
+    <ctl name="IIR0 Enable Band2" value="1" />
+    <ctl name="IIR0 Enable Band3" value="1" />
+    <ctl name="IIR0 Enable Band4" value="1" />
+    <ctl name="IIR0 Enable Band5" value="1" />
 
     <path name="deep-buffer-playback speaker">
         <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia1" value="1" />


### PR DESCRIPTION
Fix for ANC not working in Russian Manufatured Dipper (Mi8) Units due to different IIR0/Anc Frequency. This issue was causing Huge noise  reflecting during Phone-calls. Test: Call Someone and hear the sounds in reciever, There should be no noise.